### PR TITLE
wip

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -35,6 +35,7 @@ const defaultAlias = {
 };
 
 const productionPlugins = [
+  ['styled-components', { ssr: true, displayName: true, preprocess: false }],
   '@babel/plugin-transform-react-constant-elements',
   'babel-plugin-transform-dev-warning',
   ['babel-plugin-react-remove-properties', { properties: ['data-mui-test'] }],
@@ -49,6 +50,7 @@ const productionPlugins = [
 module.exports = {
   presets: defaultPresets.concat(['@babel/preset-react', '@babel/preset-typescript']),
   plugins: [
+    ['styled-components', { ssr: true, displayName: true, preprocess: false }],
     [
       'babel-plugin-macros',
       {
@@ -85,6 +87,7 @@ module.exports = {
     },
     development: {
       plugins: [
+        ['styled-components', { ssr: true, displayName: true, preprocess: false }],
         [
           'babel-plugin-module-resolver',
           {
@@ -110,6 +113,7 @@ module.exports = {
     test: {
       sourceMaps: 'both',
       plugins: [
+        ['styled-components', { ssr: true, displayName: true, preprocess: false }],
         [
           'babel-plugin-module-resolver',
           {

--- a/docs/babel.config.js
+++ b/docs/babel.config.js
@@ -21,8 +21,8 @@ const alias = {
   '@material-ui/styles': '../packages/material-ui-styles/src',
   '@material-ui/styled-engine-sc': '../packages/material-ui-styled-engine-sc/src',
   // Swap the comments on the next two lines for using the styled-components as style engine
-  '@material-ui/styled-engine': '../packages/material-ui-styled-engine/src',
-  // '@material-ui/styled-engine': '../packages/material-ui-styled-engine-sc/src',
+  // '@material-ui/styled-engine': '../packages/material-ui-styled-engine/src',
+  '@material-ui/styled-engine': '../packages/material-ui-styled-engine-sc/src',
   '@material-ui/system': '../packages/material-ui-system/src',
   '@material-ui/utils': '../packages/material-ui-utils/src',
   docs: './',
@@ -40,6 +40,7 @@ module.exports = {
     ['next/babel', { 'transform-runtime': { corejs: 2, version: transformRuntimeVersion } }],
   ],
   plugins: [
+    ['styled-components', { ssr: true, displayName: true, preprocess: false }],
     [
       'babel-plugin-macros',
       {
@@ -65,10 +66,36 @@ module.exports = {
   env: {
     production: {
       plugins: [
+        ['styled-components', { ssr: true, displayName: true, preprocess: false }],
         '@babel/plugin-transform-react-constant-elements',
         'babel-plugin-transform-dev-warning',
         ['babel-plugin-react-remove-properties', { properties: ['data-mui-test'] }],
         ['babel-plugin-transform-react-remove-prop-types', { mode: 'remove' }],
+      ],
+    },
+    development: {
+      plugins: [
+        ['styled-components', { ssr: true, displayName: true, preprocess: false }],
+        [
+          'babel-plugin-macros',
+          {
+            muiError: {
+              errorCodesPath,
+            },
+          },
+        ],
+        'babel-plugin-optimize-clsx',
+        // for IE 11 support
+        '@babel/plugin-transform-object-assign',
+        'babel-plugin-preval',
+        [
+          'babel-plugin-module-resolver',
+          {
+            alias,
+            transformFunctions: ['require', 'require.context'],
+            resolvePath,
+          },
+        ],
       ],
     },
   },

--- a/docs/package.json
+++ b/docs/package.json
@@ -60,6 +60,7 @@
     "babel-plugin-optimize-clsx": "^2.4.1",
     "babel-plugin-preval": "^2.0.0",
     "babel-plugin-react-remove-properties": "^0.3.0",
+    "styled-components": "^1.11.1",
     "babel-plugin-transform-dev-warning": "^0.1.1",
     "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
     "clean-css": "^4.1.11",

--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -311,9 +311,7 @@ function AppWrapper(props) {
 
     // Remove the server-side injected CSS.
     const jssStyles = document.querySelector('#jss-server-side');
-    if (jssStyles) {
-      jssStyles.parentElement.removeChild(jssStyles);
-    }
+    if (jssStyles && jssStyles.parentNode) jssStyles.parentNode.removeChild(jssStyles);
   }, []);
 
   const activePage = findActivePage(pages, router.pathname);

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "babel-plugin-module-resolver": "^4.0.0",
     "babel-plugin-optimize-clsx": "^2.3.0",
     "babel-plugin-react-remove-properties": "^0.3.0",
+    "styled-components": "^1.11.1",
     "babel-plugin-tester": "^9.0.0",
     "babel-plugin-transform-dev-warning": "^0.1.0",
     "babel-plugin-transform-react-remove-prop-types": "^0.4.21",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4016,15 +4016,25 @@ babel-plugin-react-remove-properties@^0.3.0:
   resolved "https://registry.yarnpkg.com/babel-plugin-react-remove-properties/-/babel-plugin-react-remove-properties-0.3.0.tgz#7b623fb3c424b6efb4edc9b1ae4cc50e7154b87f"
   integrity sha512-vbxegtXGyVcUkCvayLzftU95vuvpYFV85pRpeMpohMHeEY46Qe0VNWfkVVcCbaZ12CXHzDFOj0esumATcW83ng==
 
-"babel-plugin-styled-components@>= 1":
+"styled-components@>= 1":
   version "1.10.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-styled-components/-/babel-plugin-styled-components-1.10.0.tgz#ff1f42ad2cc78c21f26b62266b8f564dbc862939"
+  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-1.10.0.tgz#ff1f42ad2cc78c21f26b62266b8f564dbc862939"
   integrity sha512-sQVKG8irFXx14ZfaK1bBePirfkacl3j8nZwSZK+ZjsbnadRHKQTbhXbe/RB1vT6Vgkz45E+V95LBq4KqdhZUNw==
   dependencies:
     "@babel/helper-annotate-as-pure" "^7.0.0"
     "@babel/helper-module-imports" "^7.0.0"
     babel-plugin-syntax-jsx "^6.18.0"
     lodash "^4.17.10"
+
+styled-components@^1.11.1:
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-1.11.1.tgz#5296a9e557d736c3186be079fff27c6665d63d76"
+  integrity sha512-YwrInHyKUk1PU3avIRdiLyCpM++18Rs1NgyMXEAQC33rIXs/vro0A+stf4sT0Gf22Got+xRWB8Cm0tw+qkRzBA==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.0.0"
+    "@babel/helper-module-imports" "^7.0.0"
+    babel-plugin-syntax-jsx "^6.18.0"
+    lodash "^4.17.11"
 
 babel-plugin-syntax-jsx@6.18.0, babel-plugin-syntax-jsx@^6.18.0:
   version "6.18.0"
@@ -15430,7 +15440,7 @@ styled-components@^5.0.0:
     "@emotion/is-prop-valid" "^0.8.8"
     "@emotion/stylis" "^0.8.4"
     "@emotion/unitless" "^0.7.4"
-    babel-plugin-styled-components ">= 1"
+    styled-components ">= 1"
     css-to-react-native "^3.0.0"
     hoist-non-react-statics "^3.0.0"
     shallowequal "^1.1.0"
@@ -16750,9 +16760,9 @@ webpack-sources@1.4.3, webpack-sources@^1.0.1, webpack-sources@^1.1.0, webpack-s
     source-map "~0.6.1"
 
 webpack@4.44.1, webpack@^4.28.2, webpack@^4.41.0, webpack@^4.43.0, webpack@^4.44.1:
-  version "4.44.1"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.44.1.tgz#17e69fff9f321b8f117d1fda714edfc0b939cc21"
-  integrity sha512-4UOGAohv/VGUNQJstzEywwNxqX417FnjZgZJpJQegddzPmTvph37eBIRbRTfdySXzVtJXLJfbMN3mMYhM6GdmQ==
+  version "4.44.2"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.44.2.tgz#6bfe2b0af055c8b2d1e90ed2cd9363f841266b72"
+  integrity sha512-6KJVGlCxYdISyurpQ0IPTklv+DULv05rs2hseIXer6D7KrUicRDLFb4IUM1S6LUAKypPM/nSiVSuv8jHu1m3/Q==
   dependencies:
     "@webassemblyjs/ast" "1.9.0"
     "@webassemblyjs/helper-module-context" "1.9.0"


### PR DESCRIPTION
This PR tries to solve the warning 
```
react-dom.development.js:88 Warning: Prop `className` did not match. Server: "sc-gKAblj gwnHur MuiSlider-root MuiSlider-colorPrimary" Client: "sc-bdnylx fFZJOT MuiSlider-root MuiSlider-colorPrimary"
    in span (created by styled.span)
    in styled.span (at SliderUnstyled.js:623)
    in ForwardRef(Slider) (at SliderStyled.js:303)
    in ForwardRef(Slider) (at ContinuousSlider.js:33)
```

If you run it locally do some changes in the code, refresh the page you will start seeing the error after some interaction.\

The changes are based on: https://medium.com/javascript-in-plain-english/ssr-with-next-js-styled-components-and-material-ui-b1e88ac11dfa 
I cloned the repo linked there and it works as expected

I tried to make it as close as possible as the project in the example repository. The difference is how babel is used, the example project defined `.babelrc`, but we have `babel.config.js`

I also followed the comments on this issues of how to properly add the plugin: 
https://github.com/styled-components/babel-plugin-styled-components/issues/78 and tried both names for the plugin: "babel-plugin-styled-components" & "styled-components", but nothing worked so far.

My guess is that somehow the plugin is not correctly loaded, as if I remove the plugin in the example repo that I cloned, the error starts showing again after the code is changed and the page is refreshed.