### PR TITLE
generate `vars` in `extendTheme`

### DIFF
--- a/packages/mui-joy/src/styles/CssVarsProvider.tsx
+++ b/packages/mui-joy/src/styles/CssVarsProvider.tsx
@@ -4,11 +4,6 @@ import extendTheme, { CssVarsThemeOptions } from './extendTheme';
 import { createSoftInversion, createSolidInversion } from './variantUtils';
 import type { Theme, DefaultColorScheme, ExtendedColorScheme } from './types';
 
-const shouldSkipGeneratingVar = (keys: string[]) =>
-  !!keys[0].match(/^(typography|variants|breakpoints|colorInversion|colorInversionConfig)$/) ||
-  (keys[0] === 'palette' && !!keys[1]?.match(/^(mode)$/)) ||
-  (keys[0] === 'focus' && keys[1] !== 'thickness');
-
 const { CssVarsProvider, useColorScheme, getInitColorSchemeScript } = createCssVarsProvider<
   DefaultColorScheme | ExtendedColorScheme
 >({
@@ -34,7 +29,6 @@ const { CssVarsProvider, useColorScheme, getInitColorSchemeScript } = createCssV
     );
     return mergedTheme;
   },
-  shouldSkipGeneratingVar,
 });
 
-export { CssVarsProvider, useColorScheme, getInitColorSchemeScript, shouldSkipGeneratingVar };
+export { CssVarsProvider, useColorScheme, getInitColorSchemeScript };

--- a/packages/mui-joy/src/styles/index.ts
+++ b/packages/mui-joy/src/styles/index.ts
@@ -61,12 +61,8 @@ export type {
   ThemeCssVar,
   ThemeCssVarOverrides,
 } from './types/theme';
-export {
-  CssVarsProvider,
-  useColorScheme,
-  getInitColorSchemeScript,
-  shouldSkipGeneratingVar,
-} from './CssVarsProvider';
+export { CssVarsProvider, useColorScheme, getInitColorSchemeScript } from './CssVarsProvider';
+export { default as shouldSkipGeneratingVar } from './shouldSkipGeneratingVar';
 export { default as styled } from './styled';
 export { default as ThemeProvider } from './ThemeProvider';
 export * from './ThemeProvider';

--- a/packages/mui-joy/src/styles/shouldSkipGeneratingVar.ts
+++ b/packages/mui-joy/src/styles/shouldSkipGeneratingVar.ts
@@ -1,0 +1,9 @@
+export default function shouldSkipGeneratingVar(keys: string[]) {
+  return (
+    !!keys[0].match(
+      /^(typography|variants|breakpoints|colorInversion|colorInversionConfig|unstable_sxConfig|unstable_sx)$/,
+    ) ||
+    (keys[0] === 'palette' && !!keys[1]?.match(/^(mode)$/)) ||
+    (keys[0] === 'focus' && keys[1] !== 'thickness')
+  );
+}

--- a/packages/mui-joy/src/styles/types/theme.ts
+++ b/packages/mui-joy/src/styles/types/theme.ts
@@ -82,6 +82,9 @@ export interface Theme extends ThemeScales, RuntimeColorSystem {
   vars: ThemeVars;
   getCssVar: (field: ThemeCssVar, ...vars: ThemeCssVar[]) => string;
   getColorSchemeSelector: (colorScheme: DefaultColorScheme | ExtendedColorScheme) => string;
+  generateCssVars: (
+    colorScheme?: DefaultColorScheme | ExtendedColorScheme,
+  ) => Record<string, string | number>;
   unstable_sxConfig: SxConfig;
   unstable_sx: (props: SxProps) => CSSObject;
 }

--- a/packages/mui-system/src/cssVars/createCssVarsProvider.d.ts
+++ b/packages/mui-system/src/cssVars/createCssVarsProvider.d.ts
@@ -39,14 +39,6 @@ export interface CssVarsProviderConfig<ColorScheme extends string> {
    * @default false
    */
   disableTransitionOnChange?: boolean;
-  /**
-   * A function to determine if the key, value should be attached as CSS Variable
-   * `keys` is an array that represents the object path keys.
-   *  Ex, if the theme is { foo: { bar: 'var(--test)' } }
-   *  then, keys = ['foo', 'bar']
-   *        value = 'var(--test)'
-   */
-  shouldSkipGeneratingVar?: (keys: string[], value: string | number) => boolean;
 }
 
 export interface CreateCssVarsProviderResult<ColorScheme extends string> {

--- a/packages/mui-system/src/index.d.ts
+++ b/packages/mui-system/src/index.d.ts
@@ -166,6 +166,7 @@ export * from './ThemeProvider';
 
 export { default as unstable_createCssVarsProvider, CreateCssVarsProviderResult } from './cssVars';
 export { default as unstable_createGetCssVar } from './cssVars/createGetCssVar';
+export { default as unstable_cssVarsParser } from './cssVars/cssVarsParser';
 export * from './cssVars';
 
 export { default as responsivePropType } from './responsivePropType';

--- a/packages/mui-system/src/index.js
+++ b/packages/mui-system/src/index.js
@@ -58,6 +58,7 @@ export * from './colorManipulator';
 export { default as ThemeProvider } from './ThemeProvider';
 export { default as unstable_createCssVarsProvider } from './cssVars/createCssVarsProvider';
 export { default as unstable_createGetCssVar } from './cssVars/createGetCssVar';
+export { default as unstable_cssVarsParser } from './cssVars/cssVarsParser';
 export { default as responsivePropType } from './responsivePropType';
 
 /** ----------------- */


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

## Propose

If we want `extendTheme()` to produce `theme.vars`, the logic of producing variables should be in `extendTheme()`. I think it makes a lot of sense.

One major change is the `shouldSkipGeneratingVar` will be in `extendTheme` instead of `CssVarsProvider`. I think this should be fine since we haven't documented this configuration.

```diff
const theme = extendTheme({
+  shouldSkipGeneratingVar: (keys) => …,
})

<CssVarsProvider
- shouldSkipGeneratingVar={(keys) => …}
/>
```

## Changes

**Before**:

<img src="https://user-images.githubusercontent.com/18292247/216268171-2363b523-507f-49b9-a848-be3281337f7b.png" width="500" />

**After**

<img src="https://user-images.githubusercontent.com/18292247/216268233-68877375-c261-4087-92a2-f678d9044456.png" width="500" />

Generating CSS variables outside of `CssVarsProvider` sounds like a better abstraction because it does not require the current `colorScheme` or `mode` of the application. It just prepare the variables for all of the color schemes.


---

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
